### PR TITLE
feat: add ratings system and public user profile (Sprint 3)

### DIFF
--- a/backend/auth-service/app/api/v1/rating_router.py
+++ b/backend/auth-service/app/api/v1/rating_router.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.schemas.rating import RatingCreate
+from app.services.rating_service import RatingService
+from app.api.deps import get_current_user
+from app.db.session import get_db
+
+router = APIRouter(prefix="/ratings", tags=["ratings"])
+
+rating_service = RatingService()
+
+
+@router.post("")
+def create_rating(data: RatingCreate, db: Session = Depends(get_db), current_user: str = Depends(get_current_user)):
+    return rating_service.create_rating(
+        db,
+        from_user_email=current_user,
+        to_user_id=data.to_user_id,
+        transaction_id=data.transaction_id,
+        stars=data.stars,
+        review_text=data.review_text,
+    )

--- a/backend/auth-service/app/api/v1/user_router.py
+++ b/backend/auth-service/app/api/v1/user_router.py
@@ -1,0 +1,63 @@
+import os
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.repositories.user_repository import UserRepository
+from app.repositories.rating_repository import RatingRepository
+from app.core.security import create_access_token
+from app.db.session import get_db
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+user_repository = UserRepository()
+rating_repository = RatingRepository()
+
+INVENTORY_SERVICE_URL = os.getenv("INVENTORY_SERVICE_URL", "http://inventory-service:8000")
+
+
+def _get_active_listing_count(seller_email: str) -> int:
+    try:
+        service_token = create_access_token({"sub": "service@internal"})
+        headers = {"Authorization": f"Bearer {service_token}"}
+        response = httpx.get(f"{INVENTORY_SERVICE_URL}/api/v1/products", headers=headers, timeout=3.0)
+        if response.status_code == 200:
+            products = response.json()
+            return sum(
+                1 for p in products
+                if p.get("seller_id") == seller_email and p.get("state") in ("Available", "Reserved")
+            )
+    except Exception:
+        pass
+    return 0
+
+
+@router.get("/{user_id}/profile")
+def get_user_profile(user_id: int, db: Session = Depends(get_db)):
+    user = user_repository.get_user_by_id(db, user_id)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Usuario no encontrado"
+        )
+    return {
+        "username": user.email,
+        "member_since": user.created_at,
+        "avg_rating": user.avg_rating,
+        "active_listing_count": _get_active_listing_count(user.email)
+    }
+
+
+@router.get("/{user_id}/ratings")
+def get_user_ratings(user_id: int, skip: int = 0, limit: int = 20, db: Session = Depends(get_db)):
+    ratings = rating_repository.get_ratings_for_user(db, user_id, skip=skip, limit=limit)
+    result = []
+    for r in ratings:
+        reviewer = user_repository.get_user_by_id(db, r.from_user_id)
+        result.append({
+            "reviewer_username": reviewer.email if reviewer else None,
+            "stars": r.stars,
+            "review_text": r.review_text,
+            "created_at": r.created_at
+        })
+    return result

--- a/backend/auth-service/app/db/init_db.py
+++ b/backend/auth-service/app/db/init_db.py
@@ -4,6 +4,7 @@ from app.db.base import Base
 from app.db.session import SessionLocal, engine
 from app.core.security import hash_password
 from app.models.user import User
+from app.models.rating import Rating  # noqa: F401
 #from app.models.social_account import SocialAccount
 
 DATABASE_URL = str(engine.url)

--- a/backend/auth-service/app/main.py
+++ b/backend/auth-service/app/main.py
@@ -1,6 +1,8 @@
 from fastapi import FastAPI
 from app.api.v1.auth_router import router as auth_router
 from app.api.v1.social_auth_router import router as social_auth_router
+from app.api.v1.rating_router import router as rating_router
+from app.api.v1.user_router import router as user_router
 from app.db.init_db import init_db
 
 app = FastAPI()
@@ -18,3 +20,5 @@ def health():
 
 app.include_router(auth_router)
 app.include_router(social_auth_router)
+app.include_router(rating_router)
+app.include_router(user_router)

--- a/backend/auth-service/app/models/rating.py
+++ b/backend/auth-service/app/models/rating.py
@@ -1,0 +1,23 @@
+import os
+from sqlalchemy import Column, Integer, String, DateTime, UniqueConstraint
+from datetime import datetime
+from app.db.base import Base
+
+DATABASE_URL = os.getenv("AUTH_DATABASE_URL", "sqlite:///./auth.db")
+DB_SCHEMA = None if DATABASE_URL.startswith("sqlite") else os.getenv("DB_SCHEMA", None)
+
+
+class Rating(Base):
+    __tablename__ = "ratings"
+    __table_args__ = (
+        UniqueConstraint("from_user_id", "transaction_id", name="uq_rating_user_transaction"),
+        {"schema": DB_SCHEMA} if DB_SCHEMA else {},
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    from_user_id = Column(Integer, nullable=False)
+    to_user_id = Column(Integer, nullable=False, index=True)
+    transaction_id = Column(Integer, nullable=False)
+    stars = Column(Integer, nullable=False)
+    review_text = Column(String, nullable=True)
+    created_at = Column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)

--- a/backend/auth-service/app/repositories/rating_repository.py
+++ b/backend/auth-service/app/repositories/rating_repository.py
@@ -1,0 +1,29 @@
+from sqlalchemy.orm import Session
+from app.models.rating import Rating
+
+
+class RatingRepository:
+
+    def create_rating(self, db: Session, from_user_id: int, to_user_id: int, transaction_id: int, stars: int, review_text: str = None):
+        rating = Rating(
+            from_user_id=from_user_id,
+            to_user_id=to_user_id,
+            transaction_id=transaction_id,
+            stars=stars,
+            review_text=review_text,
+        )
+        db.add(rating)
+        db.commit()
+        db.refresh(rating)
+        return rating
+
+    def get_rating_by_user_and_transaction(self, db: Session, from_user_id: int, transaction_id: int):
+        return db.query(Rating).filter(
+            Rating.from_user_id == from_user_id,
+            Rating.transaction_id == transaction_id
+        ).first()
+
+    def get_ratings_for_user(self, db: Session, to_user_id: int, skip: int = 0, limit: int = 20):
+        return db.query(Rating).filter(
+            Rating.to_user_id == to_user_id
+        ).offset(skip).limit(limit).all()

--- a/backend/auth-service/app/repositories/user_repository.py
+++ b/backend/auth-service/app/repositories/user_repository.py
@@ -1,5 +1,7 @@
 from sqlalchemy.orm import Session
+from sqlalchemy import func
 from app.models.user import User
+from app.models.rating import Rating
 
 
 class UserRepository:
@@ -16,3 +18,15 @@ class UserRepository:
 
     def get_user_by_email(self, db: Session, email: str):
         return db.query(User).filter(User.email == email).first()
+
+    def get_user_by_id(self, db: Session, user_id: int):
+        return db.query(User).filter(User.id == user_id).first()
+
+    def update_avg_rating(self, db: Session, user_id: int):
+        avg = db.query(func.avg(Rating.stars)).filter(Rating.to_user_id == user_id).scalar()
+        user = self.get_user_by_id(db, user_id)
+        if user:
+            user.avg_rating = float(avg) if avg is not None else None
+            db.commit()
+            db.refresh(user)
+        return user

--- a/backend/auth-service/app/schemas/rating.py
+++ b/backend/auth-service/app/schemas/rating.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class RatingCreate(BaseModel):
+    to_user_id: int
+    transaction_id: int
+    stars: int
+    review_text: Optional[str] = None

--- a/backend/auth-service/app/services/rating_service.py
+++ b/backend/auth-service/app/services/rating_service.py
@@ -1,0 +1,99 @@
+import os
+import httpx
+from sqlalchemy.orm import Session
+from fastapi import HTTPException, status
+
+from app.repositories.rating_repository import RatingRepository
+from app.repositories.user_repository import UserRepository
+from app.core.security import create_access_token
+
+TRANSACTION_SERVICE_URL = os.getenv("TRANSACTION_SERVICE_URL", "http://transaction-service:8000")
+
+
+def _check_transaction_eligibility(transaction_id: int, from_user_email: str):
+    try:
+        service_token = create_access_token({"sub": from_user_email})
+        headers = {"Authorization": f"Bearer {service_token}"}
+        response = httpx.get(
+            f"{TRANSACTION_SERVICE_URL}/products/history",
+            headers=headers,
+            timeout=3.0
+        )
+        if response.status_code != 200:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="No se puede verificar la transacción"
+            )
+        data = response.json()
+        transactions = data if isinstance(data, list) else data.get("items", data.get("transactions", []))
+        transaction = next((t for t in transactions if t.get("id") == transaction_id), None)
+        if not transaction:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Transacción no encontrada o no tienes acceso"
+            )
+        if transaction.get("status") != "completed":
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Solo se puede valorar una transacción completada"
+            )
+        is_buyer = transaction.get("buyer_id") == from_user_email
+        is_seller = transaction.get("seller_id") == from_user_email
+        if not is_buyer and not is_seller:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="No eres parte de esta transacción"
+            )
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="No se puede verificar la transacción"
+        )
+
+
+class RatingService:
+
+    def __init__(self):
+        self.rating_repository = RatingRepository()
+        self.user_repository = UserRepository()
+
+    def create_rating(self, db: Session, from_user_email: str, to_user_id: int, transaction_id: int, stars: int, review_text: str = None):
+        if stars < 1 or stars > 5:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Las estrellas deben estar entre 1 y 5"
+            )
+
+        from_user = self.user_repository.get_user_by_email(db, from_user_email)
+        if not from_user:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Usuario no encontrado"
+            )
+
+        _check_transaction_eligibility(transaction_id, from_user_email)
+
+        existing = self.rating_repository.get_rating_by_user_and_transaction(db, from_user.id, transaction_id)
+        if existing:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Ya has valorado esta transacción"
+            )
+
+        rating = self.rating_repository.create_rating(
+            db,
+            from_user_id=from_user.id,
+            to_user_id=to_user_id,
+            transaction_id=transaction_id,
+            stars=stars,
+            review_text=review_text,
+        )
+
+        self.user_repository.update_avg_rating(db, to_user_id)
+
+        return {
+            "message": "valoración creada correctamente",
+            "rating_id": rating.id
+        }

--- a/backend/auth-service/tests/test_profile.py
+++ b/backend/auth-service/tests/test_profile.py
@@ -1,0 +1,64 @@
+def _register_and_login(client, email, password="1234"):
+    client.post("/auth/register", json={"email": email, "password": password})
+    response = client.post("/auth/login", json={"email": email, "password": password})
+    return response.json()["access_token"]
+
+
+def test_profile_returns_correct_data(client):
+    _register_and_login(client, "user1@example.com")
+
+    response = client.get("/users/1/profile")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["username"] == "user1@example.com"
+    assert "member_since" in data
+    assert "avg_rating" in data
+    assert "active_listing_count" in data
+
+
+def test_profile_user_without_ratings_has_null_avg(client):
+    _register_and_login(client, "noratings@example.com")
+
+    response = client.get("/users/1/profile")
+
+    assert response.status_code == 200
+    assert response.json()["avg_rating"] is None
+
+
+def test_profile_is_public_no_token_needed(client):
+    _register_and_login(client, "public@example.com")
+
+    response = client.get("/users/1/profile")
+
+    assert response.status_code == 200
+
+
+def test_profile_not_found_returns_404(client):
+    response = client.get("/users/9999/profile")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Usuario no encontrado"
+
+
+def test_ratings_list_is_paginated(client):
+    from unittest.mock import patch
+
+    token = _register_and_login(client, "rater@example.com")
+    client.post("/auth/register", json={"email": "rated@example.com", "password": "1234"})
+
+    with patch("app.services.rating_service._check_transaction_eligibility"):
+        for i in range(1, 4):
+            client.post(
+                "/ratings",
+                json={"to_user_id": 2, "transaction_id": i, "stars": 4},
+                headers={"Authorization": f"Bearer {token}"}
+            )
+
+    response_page1 = client.get("/users/2/ratings?skip=0&limit=2")
+    response_page2 = client.get("/users/2/ratings?skip=2&limit=2")
+
+    assert response_page1.status_code == 200
+    assert len(response_page1.json()) == 2
+    assert response_page2.status_code == 200
+    assert len(response_page2.json()) == 1

--- a/backend/auth-service/tests/test_ratings.py
+++ b/backend/auth-service/tests/test_ratings.py
@@ -1,0 +1,78 @@
+from unittest.mock import patch
+
+
+def _register_and_login(client, email, password="1234"):
+    client.post("/auth/register", json={"email": email, "password": password})
+    response = client.post("/auth/login", json={"email": email, "password": password})
+    return response.json()["access_token"]
+
+
+def test_create_rating_success(client):
+    token = _register_and_login(client, "rater@example.com")
+    client.post("/auth/register", json={"email": "rated@example.com", "password": "1234"})
+
+    with patch("app.services.rating_service._check_transaction_eligibility"):
+        response = client.post(
+            "/ratings",
+            json={"to_user_id": 2, "transaction_id": 10, "stars": 5, "review_text": "Excelente"},
+            headers={"Authorization": f"Bearer {token}"}
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["message"] == "valoración creada correctamente"
+    assert "rating_id" in data
+
+
+def test_create_rating_duplicate_returns_409(client):
+    token = _register_and_login(client, "rater@example.com")
+    client.post("/auth/register", json={"email": "rated@example.com", "password": "1234"})
+
+    payload = {"to_user_id": 2, "transaction_id": 99, "stars": 4}
+
+    with patch("app.services.rating_service._check_transaction_eligibility"):
+        client.post("/ratings", json=payload, headers={"Authorization": f"Bearer {token}"})
+        response = client.post("/ratings", json=payload, headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Ya has valorado esta transacción"
+
+
+def test_create_rating_invalid_stars_returns_422(client):
+    token = _register_and_login(client, "rater@example.com")
+
+    response = client.post(
+        "/ratings",
+        json={"to_user_id": 2, "transaction_id": 50, "stars": 10},
+        headers={"Authorization": f"Bearer {token}"}
+    )
+
+    assert response.status_code == 422
+
+
+def test_create_rating_without_token_returns_401(client):
+    response = client.post(
+        "/ratings",
+        json={"to_user_id": 2, "transaction_id": 77, "stars": 3}
+    )
+
+    assert response.status_code == 401
+
+
+def test_avg_rating_recalculated_after_multiple_ratings(client):
+    token = _register_and_login(client, "rater@example.com")
+    client.post("/auth/register", json={"email": "rated@example.com", "password": "1234"})
+
+    with patch("app.services.rating_service._check_transaction_eligibility"):
+        client.post(
+            "/ratings",
+            json={"to_user_id": 2, "transaction_id": 1, "stars": 4},
+            headers={"Authorization": f"Bearer {token}"}
+        )
+        response = client.post(
+            "/ratings",
+            json={"to_user_id": 2, "transaction_id": 2, "stars": 2},
+            headers={"Authorization": f"Bearer {token}"}
+        )
+
+    assert response.status_code == 200


### PR DESCRIPTION
## Sprint 3 - Ratings & Public Profile

### Changes
- Rating model (SQLAlchemy + Supabase table)
- POST /ratings — create rating with eligibility check (transaction must be completed, user must be buyer/seller), 409 on duplicate
- Automatic avg_rating recalculation after each rating
- GET /users/{id}/profile — public endpoint (username, member_since, avg_rating, active_listing_count)
- GET /users/{id}/ratings — paginated list with reviewer_username, stars, review_text, date
- active_listing_count via cross-service call to inventory-service
- DB indexes on avg_rating and to_user_id
- Tests: test_ratings.py, test_profile.py